### PR TITLE
Use reply_to_message.text for queries when query is empty

### DIFF
--- a/commands/image.py
+++ b/commands/image.py
@@ -35,6 +35,8 @@ def search_image(update, context, more=None):
         match = re.search(r'^/.*? (.*)', update.message.text)
         if match:
             query = match.group(1)
+        elif update.message.reply_to_message:
+            query = update.message.reply_to_message.text
         else:
             update.message.reply_text('Nada pra buscar, coloque a palavra a ser'
                                       ' buscada na frente do comando "/image cachorro"')

--- a/commands/speak.py
+++ b/commands/speak.py
@@ -27,6 +27,8 @@ def speak(update, context):
     voice = "2"  # Rafael
 
     args = context.args
+    if not args and update.message.reply_to_message:
+        args = update.message.reply_to_message.text.split(" ")
 
     if "-en" in args:
         engine = "4"


### PR DESCRIPTION
If a user replies to a message with _only_ `/speak@QueBot` or `/image@QueBot`, the bot will use the quoted message's text to build the query. If `reply_to_message` doesn't exist, the default "error" message is sent to the user as it currently does.
I didn't test with the API, but it should work nonetheless.