### PR TITLE
Use Google Cloud Text-to-Speech API for /speak command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 *~
 .venv/
+*api_key*
+.vscode/

--- a/bot.py
+++ b/bot.py
@@ -23,18 +23,19 @@ logger = logging.getLogger(__name__)
 
 START_MESSAGE = 'Oi, eu sou o Quebot!\nDigite /help para ver a lista de comandos.\nCriador: @heylouiz'
 
-HELP_MESSAGE = ('/doge    - Manda um meme do doge com frases customizadas.\n'
-                '- Usage: /doge frase1, frase2, frase3...\n'
+HELP_MESSAGE = ('/doge - Manda um meme do doge com frases customizadas.\n'
+                '   - Uso: /doge frase1, frase2, frase3...\n'
                 '/image - Busca e manda uma imagem aleatória.\n'
-                '- Uso: /image frase\n'
-                '/choose  - Escolhe uma das opções disponíveis\n'
-                '- Uso: /choose sim, não\n'
-                '/speak - Manda uma mensagem de voz com o texto.\n'
-                '- Usage: /speak texto\n'
-                'Para falar em inglês utilizar o parâmetro "-en". Uso: /speak -en text in english.'
-                ' Para usar uma voz feminina utilize o parâmetro "-w". Uso: /speak -w texto.\n'
-                '/fortune - Manda um "pensamento".\n'
-                '- Uso: /fortune [-pt pra mandar frases em português]')
+                '   - Uso: /image frase\n'
+                '/choose - Escolhe uma das opções disponíveis\n'
+                '   - Uso: /choose sim, não\n'
+                '/speak - Gera uma mensagem de voz para o texto.\n'
+                '   - Uso: /speak texto\n'
+                '   Para falar em inglês, escreva também o parâmetro "`-l`".\n'
+                '       - Uso: `/speak -l en-US text in english`.\n'
+                '   Para usar uma voz feminina, utilize o parâmetro "`-w`".\n'
+                '       - Uso: `/speak -w texto.`\n'
+                '/fortune - Manda um "pensamento."')
 
 
 # Command functions
@@ -45,7 +46,7 @@ def start(update: Update, context: CallbackContext):
 
 def help(update: Update, context: CallbackContext):
     """Send a message when the command /help is issued."""
-    update.message.reply_text(HELP_MESSAGE)
+    update.message.reply_text(HELP_MESSAGE, parse_mode="markdown")
 
 
 def error(update: Update, context: CallbackContext):

--- a/commands/speak.py
+++ b/commands/speak.py
@@ -30,6 +30,15 @@ client = texttospeech.TextToSpeechClient()
 
 
 def help():
+    return (
+        "/speak - Manda uma mensagem de voz com o texto.\n*Uso*: /speak texto\n"
+        + 'Para falar em inglês, escreva também o parâmetro "-l". Uso: /speak -l en-US text in english.\n'
+        + "Isto vale para quase qualquer idioma, utilizando o padrão [BCP-47](https://en.wikipedia.org/wiki/IETF_language_tag).\n"
+        + "\nO gênero da voz é aleatório por padrão:\n"
+        + 'Para usar uma voz masculina, utilize o parâmetro "-m". Uso: /speak -m texto.\n'
+        + 'Para usar uma voz feminina, utilize o parâmetro "-w".\n'
+        + "\nOs parâmetros podem ser colocados em qualquer lugar da mensagem."
+    )
 
 
 def generate_audio(sentence, language, gender=None):
@@ -123,8 +132,12 @@ def original_speak(update, context):
 
 @run_async
 def speak(update, context):
-    if hasattr(update.message, 'text') and "-help" in update.message.text:
-        update.message.reply_text(help())
+    if hasattr(update.message, "text") and "-help" in update.message.text:
+        update.message.reply_text(
+            help(),
+            parse_mode="markdown",
+            disable_web_page_preview=True,
+        )
         return
 
     lang = "pt-BR"

--- a/commands/speak.py
+++ b/commands/speak.py
@@ -124,10 +124,9 @@ def send_original_speak(update, context):
 
     if args.w:
         if "en" in argsLang:
-            engine = "3"
             voice = "6"  # Ashley
+            lang = "1"  # English
         else:
-            engine = "3"
             voice = "1"  # Helena
     else:
         if "en" in argsLang:

--- a/commands/speak.py
+++ b/commands/speak.py
@@ -35,6 +35,8 @@ audio_config = texttospeech.AudioConfig(
     audio_encoding=texttospeech.AudioEncoding.LINEAR16
 )
 
+BASE_URL = "{}/speak".format(os.environ['API_SERVER'])
+
 
 class SsmlVoiceGender(Enum):
     SSML_VOICE_GENDER_UNSPECIFIED = 0
@@ -73,6 +75,7 @@ def wavenet_speak(update, context, sentence, language, gender=None):
     voices = client.list_voices()
     bcp47_lang = standardize_tag(language)
 
+    # Select WaveNet voices in the given language and gender
     selectedVoices = [
         voice.name
         for voice in voices.voices

--- a/commands/speak.py
+++ b/commands/speak.py
@@ -60,9 +60,11 @@ def wavenet_speak(update, context, sentence, language, gender=None):
     # Set the text input to be synthesized
     synthesis_input = texttospeech.SynthesisInput(text=sentence)
 
-    # if not gender:
-    #     gender = "SSML_VOICE_GENDER_UNSPECIFIED"
-    if gender and "w" in gender:
+    anyGender = False
+    if not gender:
+        gender = "SSML_VOICE_GENDER_UNSPECIFIED"
+        anyGender = True
+    if gender == "w":
         gender = "FEMALE"
     else:
         gender = "MALE"
@@ -75,7 +77,7 @@ def wavenet_speak(update, context, sentence, language, gender=None):
         voice.name
         for voice in voices.voices
         if (
-            str(voice.ssml_gender) == str(SsmlVoiceGender[gender])
+            (anyGender or str(voice.ssml_gender) == str(SsmlVoiceGender[gender]))
             and bcp47_lang in voice.language_codes
             and "Standard" not in voice.name
         )

--- a/commands/speak.py
+++ b/commands/speak.py
@@ -1,22 +1,68 @@
 #!/usr/bin/env python
 import os
+import random
 import requests
 import tempfile
+from langcodes import standardize_tag
 
 from urllib.parse import quote
 from telegram.ext.dispatcher import run_async
 
-BASE_URL = "{}/speak".format(os.environ['API_SERVER'])
+from google.cloud import texttospeech
+
+
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "api_key.json"
+
+# Select the type of audio file
+audio_config = texttospeech.types.AudioConfig(
+    audio_encoding=texttospeech.enums.AudioEncoding.LINEAR16
+)
+
+# Instantiate Google TTS client
+client = texttospeech.TextToSpeechClient()
 
 
 def help():
-    return '/speak - Manda uma mensagem de voz com o texto.\n- Usage: /speak texto\n' +\
-           'Para falar em inglês utilizar o parâmetro "-en". Uso: /speak -en text in english.' +\
-           'Para usar uma voz feminina utilize o parâmetro "-w". Uso: /speak -w texto.\n'
+
+
+def generate_audio(sentence, language, gender=None):
+    # Set the text input to be synthesized
+    synthesis_input = texttospeech.types.SynthesisInput(text=sentence)
+
+    if not gender:
+        gender = "SSML_VOICE_GENDER_UNSPECIFIED"
+    elif 'w' in gender:
+        gender = "FEMALE"
+    else:
+        gender = "MALE"
+
+    # Get available voices
+    voices = client.list_voices()
+    BCP47lang = standardize_tag(language)
+    voices2 = client.list_voices(BCP47lang)
+    selectedVoices = [
+        voice.name
+        for voice in voices.voices
+        if (BCP47lang in voice.language_codes and "Standard" not in voice.name)
+    ]
+    selectedVoice = random.choice(selectedVoices)
+
+    # Build the voice request, select the language code and the ssml
+    voice = texttospeech.types.VoiceSelectionParams(
+        name=selectedVoice,
+        language_code=selectedVoice[:5],  # BCP-47 tag
+        ssml_gender=getattr(texttospeech.enums.SsmlVoiceGender, gender)
+    )
+
+    # Perform the text-to-speech request on the text input with the selected
+    # voice parameters and audio file type
+    response = client.synthesize_speech(synthesis_input, voice, audio_config)
+
+    return response
 
 
 @run_async
-def speak(update, context):
+def original_speak(update, context):
     if hasattr(update.message, 'text') and "-help" in update.message.text:
         update.message.reply_text(help())
         return
@@ -71,3 +117,40 @@ def speak(update, context):
         update.message.reply_voice(voice=r.raw)
     except Exception:
         update.message.reply_text(text="Falha ao criar mensagem de voz.")
+
+
+@run_async
+def speak(update, context):
+    if hasattr(update.message, 'text') and "-help" in update.message.text:
+        update.message.reply_text(help())
+        return
+
+    lang = "pt-BR"
+    gender = None
+
+    args = context.args
+    if not args and update.message.reply_to_message:
+        args = update.message.reply_to_message.text.split(" ")
+
+    text_to_speech = " ".join(args)
+    # print(text_to_speech)
+
+    if not text_to_speech:
+        update.message.reply_text('Nada pra falar, coloque a frase a ser'
+                                  ' falada na frente do comando, ex.: "/speak cachorro quente"')
+        return
+
+    try:
+        wavenetResponse = generate_audio(text_to_speech, lang, gender)
+    except Exception as e:
+        update.message.reply_text(text="Falha ao criar mensagem de voz.", reply_to_message_id=update.message.message_id)
+        print(e)
+        return original_speak(update, context)
+
+
+    try:
+        update.message.reply_voice(voice=wavenetResponse.audio_content)
+    except Exception as e:
+        update.message.reply_text(text="Falha ao criar mensagem de voz.")
+        print(e)
+        return original_speak(update, context)

--- a/commands/utils/rate_limiter.py
+++ b/commands/utils/rate_limiter.py
@@ -35,7 +35,7 @@ def rate_limited(max):
 
             global used_chars
 
-            rate_limit_logger.debug(f"{used_chars}, {round(elapsed_first, 1)}, {round(elapsed_last, 1)}, {round(time.perf_counter(), 1)}, {round(last_time_called[0], 1)}")
+            rate_limit_logger.debug(f"{used_chars}, {round(elapsed_first, 1)}, {round(elapsed_last, 1)}, {round(last_time_called[0], 1)}")
 
             # If char limit was exceeded within the time limit, stop
             if used_chars > GCP_TTS_CHAR_LIMIT and elapsed_first < RATE_LIMIT_TIMEFRAME:

--- a/commands/utils/rate_limiter.py
+++ b/commands/utils/rate_limiter.py
@@ -9,7 +9,7 @@ rate_limit_logger = logging.getLogger(__name__)
 rate_limit_logger.setLevel(logging.DEBUG)
 
 
-GCP_TTS_FREE_QUOTA = 1000000
+GCP_TTS_FREE_QUOTA = 1000000  # 1000000 characters/month
 GCP_TTS_CHAR_LIMIT = math.floor(GCP_TTS_FREE_QUOTA / 31 / 24) - 1  # Max chars per hour
 RATE_LIMIT_TIMEFRAME = 60 * 60  # 1 hour
 used_chars = 0

--- a/commands/utils/rate_limiter.py
+++ b/commands/utils/rate_limiter.py
@@ -1,0 +1,79 @@
+import math
+import logging
+import time
+
+from functools import wraps
+
+
+rate_limit_logger = logging.getLogger(__name__)
+rate_limit_logger.setLevel(logging.DEBUG)
+
+
+GCP_TTS_CHAR_LIMIT = math.floor(1000000 / 31 / 24) - 1  # Max chars per hour
+RATE_LIMIT = 60 * 60  # 1 hour
+used_chars = 0
+
+
+def rate_limited(max):
+    """
+    Decorator that makes functions not be called more than `max` times per second.
+    """
+
+    # Minimum interval between each call of decorated function
+    min_interval = 1.0 / float(max)
+
+    def decorate(func):
+        # Initializate first and last time function was called, respectively
+        first_time_called = [0.0]
+        last_time_called = [0.0]
+
+        @wraps(func)
+        def rate_limited_function(*args, **kwargs):
+            # Time since first and last call, respectively
+            elapsed_first = time.perf_counter() - first_time_called[0]
+            elapsed = time.perf_counter() - last_time_called[0]
+
+            global used_chars
+
+            rate_limit_logger.warning(f"{used_chars}, {round(elapsed_first, 1)}, {round(elapsed, 1)}, {round(time.perf_counter(), 1)}, {round(last_time_called[0], 1)}")
+
+            # If char limit was exceeded within the time limit, stop
+            if used_chars > GCP_TTS_CHAR_LIMIT and elapsed_first < RATE_LIMIT:
+                rate_limit_logger.warning(f'Char limit exceeded within the time limit (used: {used_chars} under {round(elapsed_first, 2)} seconds, max: {GCP_TTS_CHAR_LIMIT} under {RATE_LIMIT} seconds).')
+                return
+            else:
+                if elapsed_first >= RATE_LIMIT:  # The time limit has expired,
+                    # Reset counters
+                    rate_limit_logger.debug(f'More than {RATE_LIMIT} seconds have passed, resetting rate limit counters...')
+                    first_time_called[0] = time.perf_counter()
+                    used_chars = 0
+
+                # Update when function was last called
+                last_time_called[0] = time.perf_counter()
+
+                left_to_wait = min_interval - elapsed
+                # Too many calls for the given max number of calls per second
+                if left_to_wait > 0:
+                    rate_limit_logger.warning(f'Rate limit ({max}) exceeded.')
+                    return
+                else:
+                    # All rate limits have been satisfied, proceed
+                    ret = func(*args, **kwargs)
+
+                    return ret
+
+        return rate_limited_function
+
+    return decorate
+
+
+@rate_limited(max=10)
+def print_num(num):
+    time.sleep(0.1)
+    pass
+
+
+print("send print requests to decorated function")
+for i in range(1, 100):
+    print_num(i)
+    used_chars += i

--- a/commands/utils/rate_limiter.py
+++ b/commands/utils/rate_limiter.py
@@ -9,10 +9,10 @@ rate_limit_logger = logging.getLogger(__name__)
 rate_limit_logger.setLevel(logging.DEBUG)
 
 
-GCP_TTS_CHAR_LIMIT = math.floor(1000000 / 31 / 24) - 1  # Max chars per hour
-RATE_LIMIT = 60 * 60  # 1 hour
+GCP_TTS_FREE_QUOTA = 1000000
+GCP_TTS_CHAR_LIMIT = math.floor(GCP_TTS_FREE_QUOTA / 31 / 24) - 1  # Max chars per hour
+RATE_LIMIT_TIMEFRAME = 60 * 60  # 1 hour
 used_chars = 0
-
 
 def rate_limited(max):
     """
@@ -35,16 +35,16 @@ def rate_limited(max):
 
             global used_chars
 
-            rate_limit_logger.warning(f"{used_chars}, {round(elapsed_first, 1)}, {round(elapsed_last, 1)}, {round(time.perf_counter(), 1)}, {round(last_time_called[0], 1)}")
+            rate_limit_logger.debug(f"{used_chars}, {round(elapsed_first, 1)}, {round(elapsed_last, 1)}, {round(time.perf_counter(), 1)}, {round(last_time_called[0], 1)}")
 
             # If char limit was exceeded within the time limit, stop
-            if used_chars > GCP_TTS_CHAR_LIMIT and elapsed_first < RATE_LIMIT:
-                rate_limit_logger.warning(f'Char limit exceeded within the time limit (used: {used_chars} under {round(elapsed_first, 2)} seconds, max: {GCP_TTS_CHAR_LIMIT} under {RATE_LIMIT} seconds).')
+            if used_chars > GCP_TTS_CHAR_LIMIT and elapsed_first < RATE_LIMIT_TIMEFRAME:
+                rate_limit_logger.warning(f'Char limit exceeded within the time limit (used: {used_chars} under {round(elapsed_first, 2)} seconds, max: {GCP_TTS_CHAR_LIMIT} under {RATE_LIMIT_TIMEFRAME} seconds).')
                 raise ValueError(f"Char limit exceeded within the time limit.")
             else:
-                if elapsed_first >= RATE_LIMIT:  # The time limit has expired,
+                if elapsed_first >= RATE_LIMIT_TIMEFRAME:  # The time limit has expired,
                     # Reset counters
-                    rate_limit_logger.debug(f'More than {RATE_LIMIT} seconds have passed, resetting rate limit counters...')
+                    rate_limit_logger.debug(f'More than {RATE_LIMIT_TIMEFRAME} seconds have passed, resetting rate limit counters...')
                     first_time_called[0] = time.perf_counter()
                     used_chars = 0
 
@@ -68,17 +68,18 @@ def rate_limited(max):
     return decorate
 
 
-@rate_limited(max=10)
-def print_num(num):
-    time.sleep(0.1)
-    pass
+if __name__ == '__main__':
+    @rate_limited(max=10)
+    def print_num(num):
+        time.sleep(0.1)
+        pass
 
 
-print("send print requests to decorated function")
-for i in range(1, 100):
-    try:
-        print_num(i)
-    except ValueError as e:
-        print(e)
-    else:
-        used_chars += i
+    print("Sending print requests to decorated function")
+    for i in range(1, 60):
+        try:
+            print_num(i)
+        except ValueError as e:
+            print(e)
+        else:
+            used_chars += i

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-telegram-bot
 requests
+google-cloud-texttospeech
+langcodes


### PR DESCRIPTION
This PR changes `/speak` default behavior to try synthesizing voices with Google Cloud Text-to-Speech (gTTS) API first. Help messages were changed accordingly.
It also refactors how arguments are parsed, by leveraging Python's native lib, `argparse`.

Changes tangent to this functionality that were included in the PR:
- creation of a rate limiter that can be used with any function;
- use of `logging` for some portions of the code;
- slight update/improvement of the `help` message;
- removal of some unused packages;
- the aforementioned use of `argparse` to replace naive parsing of arguments.

This PR tries to maintain _some_ backward compatibility, e.g.: if a user sends `/speak -en Hello, World` but gTTS fails, the current API will receive `-en` as an argument and generate speech with an English voice. Note that gTTS uses BCP-47 language codes, so `en` is not valid, although `en_US` or `en_GB` are (for convenience, the user is also able to input non-standardized codes such as `en-us` or `en_gb`)

Resolves #9.